### PR TITLE
HOTFIX limit instance retries

### DIFF
--- a/lib/outputManager.py
+++ b/lib/outputManager.py
@@ -29,7 +29,7 @@ class OutputManager():
         pass
 
     @classmethod
-    def putKinesis(cls, data, stream, recType='work'):
+    def putKinesis(cls, data, stream, recType='work', attempts=None):
         """Puts records into a Kinesis stream for processing by other parts of
         the SFR data pipeline. Takes data as an object and converts it into a
         JSON string. This is then passed to the specified stream.
@@ -43,6 +43,8 @@ class OutputManager():
             'data': data,
             'type': recType
         }
+        if attempts is not None:
+            outputObject['attempts'] = attempts
 
         # The default lambda function here converts all objects into dicts
         kinesisStream = OutputManager._convertToJSON(outputObject)


### PR DESCRIPTION
A previous update allowed `instance` records to be retried if a matching parent record could not be found. However, this can cause a feedback loop if the parent record was dropped or errored in some way.

This implements a basic retry check (with a max of 3) to ensure that any 'orphan' instance records are recorded and dropped. This should indicate a true missing parent as placing the records at the end of the input stream means that they should be the last records to be processed in the current batch.