### PR TITLE
SFR-660 Add cover updater

### DIFF
--- a/lib/dbManager.py
+++ b/lib/dbManager.py
@@ -3,6 +3,7 @@ from helpers.logHelpers import createLog
 from lib.updaters.workUpdater import WorkUpdater
 from lib.updaters.instanceUpdater import InstanceUpdater
 from lib.updaters.itemUpdater import ItemUpdater
+from lib.updaters.coverUpdater import CoverUpdater
 
 logger = createLog('db_manager')
 
@@ -10,7 +11,8 @@ logger = createLog('db_manager')
 updaters = {
     'work': WorkUpdater,
     'instance': InstanceUpdater,
-    'item': ItemUpdater
+    'item': ItemUpdater,
+    'cover': CoverUpdater,
 }
 
 

--- a/lib/updaters/coverUpdater.py
+++ b/lib/updaters/coverUpdater.py
@@ -1,0 +1,66 @@
+from copy import copy
+from datetime import datetime
+import json
+import os
+
+from .abstractUpdater import AbstractUpdater
+from sfrCore import Link
+from lib.outputManager import OutputManager
+from helpers.errorHelpers import DBError
+
+
+class CoverUpdater(AbstractUpdater):
+    def __init__(self, record, session):
+        self.data = record.get('data')
+        self.attempts = int(record.get('attempts', 0))
+        self.link = None
+        super().__init__(record, session)
+
+    @property
+    def identifier(self):
+        return self.link.id
+
+    def lookupRecord(self):
+        currentURL = self.data.pop('originalURL', None)
+        self.logger.debug('Updating Cover from {}'.format(
+            currentURL if currentURL else '[unknown]'
+        ))
+        dbURL = Link.httpRegexSub(currentURL)
+        self.link = self.session.query(Link).filter(Link.url == dbURL).first()
+        if self.link is None:
+            if self.attempts < 3:
+                self.logger.warning(
+                    """Attempt {} Could not locate link, placing at end of queue
+                    """.format(
+                        self.attempts + 1
+                    )
+                )
+                OutputManager.putKinesis(
+                    self.data,
+                    os.environ['UPDATE_STREAM'],
+                    recType='link',
+                    attempts=self.attempts + 1
+                )
+                raise DBError(
+                    'links',
+                    """Could not locate link in database, moving to end of queue
+                    """
+                )
+            else:
+                raise DBError('links', 'Failed to find link in db. Dropping')
+
+    def updateRecord(self):
+        self.link.url = self.data.get('storedURL')
+        # SQLAlchemy checks if the object reference has changed, so we cannot
+        # just update this object, it must be copied and then altered
+        try:
+            tmpFlags = copy(json.loads(self.link.flags))
+        except TypeError:
+            tmpFlags = copy(self.link.flags)
+        tmpFlags['temporary'] = False
+        self.link.flags = tmpFlags
+
+    def setUpdateTime(self):
+        if len(self.link.instances) == 0:
+            raise DBError('links', 'Cover must be associated with an instance')
+        self.link.instances[0].work.date_modified = datetime.utcnow()

--- a/service.py
+++ b/service.py
@@ -51,6 +51,8 @@ def parseRecords(records):
     """Iterator for handling multiple incoming messages"""
     logger.debug('Parsing Messages')
 
+    MANAGER.createSession()
+
     try:
         parseResults = [parseRecord(r) for r in records]
         logger.debug('Parsed {} records. Committing results'.format(

--- a/tests/test_coverUpdater.py
+++ b/tests/test_coverUpdater.py
@@ -1,0 +1,87 @@
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+from helpers.errorHelpers import DBError
+
+os.environ['REDIS_HOST'] = 'test_host'
+
+from lib.outputManager import OutputManager  # noqa: E402
+from lib.updaters.coverUpdater import CoverUpdater  # noqa: E402
+
+
+class TestCoverUpdater(unittest.TestCase):
+    def test_UpdaterInit(self):
+        testUpdater = CoverUpdater({'data': 'data'}, 'session')
+        self.assertEqual(testUpdater.data, 'data')
+        self.assertEqual(testUpdater.session, 'session')
+        self.assertEqual(testUpdater.attempts, 0)
+
+    def test_getIdentifier(self):
+        testUpdater = CoverUpdater({'data': {}}, 'session')
+        testLink = MagicMock()
+        testLink.id = 1
+        testUpdater.link = testLink
+        self.assertEqual(testUpdater.identifier, 1)
+
+    def test_lookupRecord_success(self):
+        mockSession = MagicMock()
+        mockSession.query().filter().first.return_value = 'existing_link'
+        testUpdater = CoverUpdater({'data': {}}, mockSession)
+        testUpdater.lookupRecord()
+        self.assertEqual(testUpdater.link, 'existing_link')
+
+    @patch.dict('os.environ', {'UPDATE_STREAM': 'test'})
+    @patch.object(OutputManager, 'putKinesis')
+    def test_lookupRecord_missing(self, mockPut):
+        mockSession = MagicMock()
+        mockSession.query().filter().first.return_value = None
+        testUpdater = CoverUpdater({'data': {}}, mockSession)
+        with self.assertRaises(DBError):
+            testUpdater.lookupRecord()
+            mockPut.assert_called_once_with(
+                {'data': {}},
+                'test',
+                recType='cover',
+                attempts=1
+            )
+
+    def test_lookupRecord_missing_retries_exceeded(self):
+        mockSession = MagicMock()
+        mockSession.query().filter().first.return_value = None
+        testUpdater = CoverUpdater({'data': {}, 'attempts': 3}, mockSession)
+        with self.assertRaises(DBError):
+            testUpdater.lookupRecord()
+
+    @patch.dict('os.environ', {'EPUB_STREAM': 'test'})
+    @patch.object(OutputManager, 'putKinesis')
+    def test_updateRecord(self, mockPut):
+        mockLink = MagicMock()
+        mockLink.flags = {'temporary': True}
+        testUpdater = CoverUpdater({'data': {'storedURL': 's3URL'}}, 'session')
+        testUpdater.link = mockLink
+
+        testUpdater.updateRecord()
+        self.assertEqual(mockLink.url, 's3URL')
+        self.assertEqual(mockLink.flags['temporary'], False)
+
+    @patch('lib.updaters.coverUpdater.datetime')
+    def test_setUpdateTime(self, mockUTC):
+        testUpdater = CoverUpdater({'data': {}}, 'session')
+        testLink = MagicMock()
+        testUpdater.link = testLink
+        testInstance = MagicMock()
+        testLink.instances = [testInstance]
+        mockUTC.utcnow.return_value = 1000
+        testUpdater.setUpdateTime()
+        self.assertEqual(
+            testUpdater.link.instances[0].work.date_modified, 1000
+        )
+
+    def test_setUpdateTime_noInstance(self):
+        testUpdater = CoverUpdater({'data': {}}, 'session')
+        testLink = MagicMock()
+        testUpdater.link = testLink
+        testLink.instances = []
+        with self.assertRaises(DBError):
+            testUpdater.setUpdateTime()


### PR DESCRIPTION
The ingest pipeline will store cover records asynchronously so the updater function must be able to handle these records as they will be sent separate from the `instance` records they will be attached to.

This will operate by looking up the temporary, remote url that is originally set and replace it with the local url generated by the cover storage function.