### PR TITLE
SFR-703 Add primary identifier to retry attempts

### DIFF
--- a/lib/updaters/workUpdater.py
+++ b/lib/updaters/workUpdater.py
@@ -45,6 +45,8 @@ class WorkUpdater(AbstractUpdater):
                         self.attempts + 1
                     )
                 )
+                if primaryID is not None:
+                    self.data['primary_identifier'] = primaryID
                 self.kinesisMsgs[os.environ['UPDATE_STREAM']].append({
                     'data': self.data,
                     'recType': 'work',

--- a/service.py
+++ b/service.py
@@ -1,5 +1,6 @@
 import base64
 import binascii
+from copy import deepcopy
 import json
 import os
 from sqlalchemy.exc import OperationalError, IntegrityError
@@ -108,7 +109,7 @@ def parseRecord(encodedRec, updater):
     outRec = None
     try:
         MANAGER.startSession()  # Start transaction
-        outRec = updater.importRecord(record)
+        outRec = updater.importRecord(deepcopy(record))
         MANAGER.commitChanges()
     except OperationalError as opErr:
         logger.error('Conflicting updates caused deadlock, retry')


### PR DESCRIPTION
When deadlocks are encountered we must retry the blocked record, however the `primary_identifier was being "popped" from the record meaning that it could not be matched to the proper row in the database and would be dropped. This ensures that this identifier (the work's UUID) in always attached when a record is passed back into the update stream